### PR TITLE
Add specific tier tag for kbs test

### DIFF
--- a/Functional/kbs-fake-token-get-resource/main.fmf
+++ b/Functional/kbs-fake-token-get-resource/main.fmf
@@ -20,6 +20,7 @@ test: ./runtest.sh
 framework: beakerlib
 tag:
   - CI-Tier-1
+  - CI-Tier-1-kbs
 require:
   - trustee-kbs
   - openssl


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Update the kbs-fake-token-get-resource functional test metadata to reflect its execution tier.